### PR TITLE
Stop treating empty space character as word character

### DIFF
--- a/src/formatters.js
+++ b/src/formatters.js
@@ -1,7 +1,7 @@
 define(['./constants'], function (constants) {
 
   function isWordCharacter(character) {
-      return /[^\s()]/.test(character);
+      return /[^\s()]/.test(character) && character.charCodeAt(0) !== 8203;
   }
 
   function replaceQuotesFromContext(openCurly, closeCurly) {


### PR DESCRIPTION
Allows noting out quotes using scribe-plugin-noting. Fixes #32 .
Broken tests are not regressions.
